### PR TITLE
switch paddle build command from cmake to comprehensive paddle_build.sh

### DIFF
--- a/build_paddle.xsh
+++ b/build_paddle.xsh
@@ -12,7 +12,8 @@ subprocess.call("WITH_TESTING=OFF "
     "WITH_GPU=ON "
     "WITH_STYLE_CHECK=OFF "
     "WITH_FLUID_ONLY=ON "
-    "WITH_MKL=OFF "
+    "WITH_MKL=ON "
+    "WITH_MKLDNN=ON "
     "WITH_DISTRIBUTE=ON "
     "paddle/scripts/paddle_build.sh build",
     shell=True,

--- a/build_paddle.xsh
+++ b/build_paddle.xsh
@@ -4,27 +4,19 @@ $XONSH_SHOW_TRACEBACK = True
 
 import sys; sys.path.insert(0, '')
 import config
-import os
+import subprocess
 
-num_workers = os.environ.get('num_workers', 8)
-
-cd @(config.paddle_path)
-mkdir -p build
-cd build
-
-# compile_mode env should be set in teamcity
-cmake .. -DWITH_TESTING=OFF \
-         -DWITH_GOLANG=OFF \
-         -DCMAKE_BUILD_TYPE=Release \
-         -DWITH_GPU=ON \
-         -DWITH_STYLE_CHECK=OFF \
-         -DWITH_FLUID_ONLY=ON \
-         -DWITH_MKLDNN=off
-
-# clean whl
-rm -rf python/dist/*
-rm -rf python/build
-make -j @(num_workers)
-make install
+subprocess.call("WITH_TESTING=OFF "
+    "WITH_GOLANG=OFF "
+    "CMAKE_BUILD_TYPE=Release "
+    "WITH_GPU=ON "
+    "WITH_STYLE_CHECK=OFF "
+    "WITH_FLUID_ONLY=ON "
+    "WITH_MKL=OFF "
+    "WITH_DISTRIBUTE=ON "
+    "paddle/scripts/paddle_build.sh build",
+    shell=True,
+    cwd=config.paddle_path
+)
 
 pip install --upgrade python/dist/*.whl


### PR DESCRIPTION
switched from cmake to paddle_build.sh to build paddle
added WITH_DISTRIBUTE=ON

to be able to:

1. run dist test.
1. generate docker file for creating dist training images

***NOT throughoutly tested, please help verify and make any changes needed***