### PR TITLE
set relative paddle path in env

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,8 +10,8 @@ pjoin = os.path.join
 #   modelce/
 #     tasks
 # DEBUG
-rpath = os.environ.get('rpath', '..')
-paddle_path = pjoin(workspace, rpath)
+relative_path = os.environ.get('relative_path', '..')
+paddle_path = pjoin(workspace, relative_path)
 #paddle_path = '/chunwei/Paddle'
 
 baseline_repo_url = 'git@github.com:PaddlePaddle/paddle-ce-latest-kpis.git'

--- a/config.py
+++ b/config.py
@@ -10,7 +10,8 @@ pjoin = os.path.join
 #   modelce/
 #     tasks
 # DEBUG
-paddle_path = pjoin(workspace, '..')
+rpath = os.environ.get('rpath', '..')
+paddle_path = pjoin(workspace, rpath)
 #paddle_path = '/chunwei/Paddle'
 
 baseline_repo_url = 'git@github.com:PaddlePaddle/paddle-ce-latest-kpis.git'


### PR DESCRIPTION
 CE pr 自动拉下来代码在当前目录，  paddle目录默认在 该目录的上层目录， 上层是非空的 ， 直接clone 到上层不好。