### PR TITLE
fix bugs that dict unordered

### DIFF
--- a/main.xsh
+++ b/main.xsh
@@ -127,7 +127,7 @@ def evaluate_tasks(args):
         
     for task in tasks:
         try:
-            passed, eval_infos, kpis, kpi_types = evaluate(task)
+            passed, eval_infos, kpis, kpi_values, kpi_types = evaluate(task)
             if mode != "baseline_test":
                 log.warn('add evaluation %s result to mongodb' % task)
                 kpi_objs = get_kpi_tasks(task)
@@ -138,6 +138,7 @@ def evaluate_tasks(args):
                                               passed = passed,
                                               infos = eval_infos,
                                               kpis = kpis,
+                                              kpi_values = kpi_values,
                                               kpi_types = kpi_types,
                                               kpi_objs = kpi_objs)
             if not passed:
@@ -176,24 +177,24 @@ def evaluate(task_name):
 
         # evaluate all the kpis
         eval_infos = []
-        kpis = {}
-        kpi_types = {}
+        kpis = []
+        kpi_values = []
+        kpi_types = []
         passed = True
         for kpi in tracking_kpis:
-            log.info("start to evaluation %s" % kpi)
             suc = kpi.evaluate(task_dir)
             if (not suc) and kpi.actived:
                 ''' Only if the kpi is actived, its evaluation result would affect the overall tasks's result. '''
                 passed = False
                 log.error("Task [%s] failed!" % task_name)
                 log.error("details:", kpi.fail_info)
-            log.info("evaluation kpi suc %s" % kpi)
-            kpis[kpi.name] = kpi.cur_data
-            kpi_types[kpi.name] = kpi.__class__.__name__
+            kpis.append(kpi.name)
+            kpi_values.append(kpi.cur_data)
+            kpi_types.append(kpi.__class__.__name__)
             # if failed, still continue to evaluate the other kpis to get full statistics.
             eval_infos.append(kpi.fail_info if not suc else kpi.success_info)
         log.info("evaluation kpi info: %s %s %s" % (passed, eval_infos, kpis))
-        return passed, eval_infos, kpis, kpi_types
+        return passed, eval_infos, kpis, kpi_values, kpi_types
 
 
 def get_tasks():

--- a/persistence.py
+++ b/persistence.py
@@ -8,7 +8,7 @@ import json
 db = MongoDB(config.db_name, host=config.db_host, port=config.db_port)
 
 
-def add_evaluation_record(commitid, date, task, passed, infos, kpis, kpi_types,
+def add_evaluation_record(commitid, date, task, passed, infos, kpis, kpi_values, kpi_types,
                           kpi_objs):
     '''
     persist the evaluation infomation of a task to the database.
@@ -36,12 +36,14 @@ def add_evaluation_record(commitid, date, task, passed, infos, kpis, kpi_types,
         'type': 'kpi',
         'passed': passed,
         'infos': infos,
-        'kpis-keys': list(kpis.keys()),
+        'kpis-keys': kpis,
         'kpis-values':
-        json.dumps(list(kpis[key].tolist() for key in kpis.keys())),
-        'kpi-types': [kpi_types[key] for key in kpis.keys()],
+        json.dumps(list(value.tolist() for value in kpi_values)),
+        'kpi-types': kpi_types,
         'kpi-activeds': [kpi.actived for kpi in kpi_objs],
         'kpi-unit-reprs': [kpi.unit_repr for kpi in kpi_objs],
         'kpi-descs': [kpi.desc for kpi in kpi_objs],
     }
     db.insert_one(config.table_name, record)
+
+


### PR DESCRIPTION
for example：the kpi seq in text_classification is:
```sh
lstm_train_cost_kpi = CostKpi('lstm_train_cost', 5, 0)
lstm_pass_duration_kpi = DurationKpi('lstm_pass_duration', 0.03, 0, actived=False)
lstm_train_cost_kpi_card4 = CostKpi('lstm_train_cost_card4', 0.2, 0)
lstm_pass_duration_kpi_card4 = DurationKpi('lstm_pass_duration_card4', 0.02, 0, actived=True)

tracking_kpis = [
              lstm_train_cost_kpi, lstm_pass_duration_kpi,
              lstm_train_cost_kpi_card4, lstm_pass_duration_kpi_card4,
                ]
```
https://github.com/PaddlePaddle/paddle-ce-latest-kpis/blob/master/text_classification/continuous_evaluation.py

**the bug will lead to an random odrer， which will lead to the actived , unit and desc are not correct for an certain kpi**
```sh
'task': 'text_classification',
'kpis-keys': ['lstm_train_cost', 'lstm_pass_duration_card4', 'lstm_train_cost_card4', 'lstm_pass_duration'],**
'date': '1525692038',
'kpi-activeds': [False, False, False, True],

```

the correct is as below：
```sh
'task': 'text_classification',
'kpi-activeds': [False, False, False, True],
'kpis-keys': ['lstm_train_cost', 'lstm_pass_duration', 'lstm_train_cost_card4', 'lstm_pass_duration_card4']

```